### PR TITLE
update the fight path

### DIFF
--- a/src/documentaries.json
+++ b/src/documentaries.json
@@ -18,7 +18,7 @@
     {
         "title": "The Fight",
         "description": "Occupying and protesting for disability rights in Bolivia",
-        "url": "https://www.theguardian.com/world/ng-interactive/2017/may/05/fighting-for-a-pension-disability-rights-protestors-in-bolivia-on-the-barricades",
+        "url": "https://www.theguardian.com/world/ng-interactive/2017/may/05/fighting-for-a-pension-disability-rights-protesters-in-bolivia-face-barricades",
         "poster": "The-Fight.jpg",
         "header": "The-Fight.jpg",
         "handle": "the-fight"


### PR DESCRIPTION
Not too sure what happened, but CP had to set up a redirect over the weekend to fix some links on fronts. Although the redirect is still in place, its better to avoid the 301 hop.